### PR TITLE
Fix the size for the Searchbar/Style checkbox

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -32,12 +32,16 @@ export default function SearchBar(){
 
         return (
             <form id='job' className={`${styles['searchbar']}`} onSubmit={handleSubmit(onSubmit)}>
+                <div>
                 <SearchInput register={register} searchParam={"jobDescriptor"} Icon={SearchIcon} placeholder="Enter desired job..." />
+                </div>
+                <div>
                 <SearchInput register={register} searchParam={"jobLocation"}  Icon={LocationIcon} placeholder="Filter by location..." />
+                </div>
                 <div className={`flex justify-between align-center ${styles["searchbar-search"]}`}>
-                    <div className={`flex ${styles['searchbar-full-time']}`}>
-                        <input className={`${styles["searchbar-checkbox"]}`} type="checkbox" {...register("fullTime")} />
-                        <h4>Full Time</h4>
+                    <div className={`flex align-center ${styles['searchbar-full-time']}`}>
+                        <input id="full-time" className={`${styles["searchbar-checkbox"]}`} type="checkbox" {...register("fullTime")} />
+                        <label htmlFor="full-time" className={`${styles["searchbar-ft-text"]}`}>Full Time</label>
                     </div>
                     <Button buttonType='submit' placeholderText='Search'/>
                 </div>

--- a/src/components/SearchBar/styles.module.css
+++ b/src/components/SearchBar/styles.module.css
@@ -1,26 +1,62 @@
-
-
 .searchbar {
     display: grid;
-    grid-template-columns: auto auto 270px;
+    grid-template-columns: auto auto 35%;
     width: 100%;
     background-color: white;
     border-radius: 6px;
-    padding: 0px 8px;
-    gap: 20px;
+    padding: 0px 0px;
+    gap: 1.7%;
 }
+
+.searchbar > div {
+    padding-left: 4%;
+}
+
 .searchbar-full-time {
-    gap: 8px;
+    gap: 8%;
 }
+
+.searchbar-ft-text {
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 18px;
+}
+
 .searchbar-search {
-    gap: 5px;
+    gap: 8%;
+    padding-left: 5%;
+    padding-right: 5%;
     white-space: nowrap;
 }
 
-.searchbar-checkbox:hover {
-    bakground-color: #939BF4;
+.searchbar-checkbox {
+    width: 22px;
+    height: 22px;
+    margin: 0px;
+    flex-shrink: 0;
+}
+
+.searchbar-checkbox::before {
+    content:"";
+    display: block;
+    position: relative;
+    height: 22px;
+    width: 22px;
+    left: 0;
+    top: 0;
+    opacity: 0;
+    background-color: #939BF4;
+    border-radius: 4px; 
+}
+
+.searchbar-checkbox:hover::before {
+    opacity: 0.5;
+}
+
+.searchbar-checkbox:checked:hover::before {
+    opacity: 0;
 }
 
 .searchbar-checkbox:checked {
-    background-color: #9e7f66;
+    accent-color: #5964E0;
 }


### PR DESCRIPTION
The original padding for the SearchBar overflowed out of container. I moved the padding into the divs for each section of the bar. The checkbox was also not adequately styled and lacked correct dimensions, accent color, and lacked a hover animation. 