### PR TITLE
Adds correct HEX value to button 2 day color

### DIFF
--- a/src/components/Button/styles.module.css
+++ b/src/components/Button/styles.module.css
@@ -20,7 +20,7 @@
 
 .button-2-day {
     color: #5964E0;
-    background-color: #EEEFC;
+    background-color: #EEEFFD;
 }
 
 .button-2-day:hover {


### PR DESCRIPTION
The button wasn't showing up with the right color in iPhone. Checked devtools and it was considered an invalid color despite showing up correctly on desktop